### PR TITLE
Feat: added functionality to get info of all saved accounts

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@
 
 A secure CLI tool for managing multiple GitHub accounts with SSH keys. Switch between work and personal accounts seamlessly! 🔐
 
-![GitShift Demo](https://via.placeholder.com/800x400.png?text=GitShift+Terminal+Demo)
+![GitShift Demo](https://github.com/user-attachments/assets/fb29cf9f-0e87-4ef9-b12a-691cdc15fc48)
 
 ## Features ✨
 
@@ -17,12 +17,12 @@ A secure CLI tool for managing multiple GitHub accounts with SSH keys. Switch be
 
 ## Installation 📦
 
-### From Source (Recommended)
+### From Source
 ```bash
-cargo install --git https://github.com/yourusername/gitshift.git
+cargo install --git https://github.com/rohansen856/gitshift.git
 ```
 
-### From crates.io
+### From crates.io (Recommended)
 ```bash
 cargo install gitshift
 ```
@@ -70,16 +70,17 @@ gitshift clone git@github.com:company/project.git
 
 ## Command Reference 📚
 
-Command	 |    Description	        |     Example
+Command	 |    Description	        |    Example
 add	     |    Create new account	|    gitshift add --name dev --algorithm rsa
 ls	     |    List accounts	        |    gitshift ls
 activate |	  Switch account	    |    gitshift activate personal
 clone	 |    Clone repository	    |    gitshift clone git@github.com:user/repo.git
+info     |    Show account details  |    gitshift info work
 
 ## Development 🛠️
 ### Build Instructions
 ```bash
-git clone https://github.com/yourusername/gitshift.git
+git clone https://github.com/rohansen856/gitshift.git
 cd gitshift
 cargo build --release
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,4 +21,6 @@ pub enum Commands {
         #[arg(short, long)]
         name: String,
     },
+    /// Get information about a specific account
+    Info { account_name: String },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         Commands::Ls => gitshift.list_accounts()?,
         Commands::Activate { account_name } => gitshift.activate_account(&account_name)?,
         Commands::Clone { repo_url } => gitshift.clone_repo(&repo_url)?,
+        Commands::Info { account_name } => {
+            gitshift.get_account_info(&account_name)?;
+        }
         Commands::Add { name } => {
             let algorithm = Algorithm::Ed25519;
             print!("{}", "Enter email for this account: ".cyan());

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use colored::Colorize;
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use ssh_key::Algorithm;
@@ -138,6 +139,36 @@ impl GitShift {
             .env("GIT_SSH_COMMAND", ssh_command)
             .spawn()?
             .wait()?;
+
+        Ok(())
+    }
+
+    pub fn get_account_info(&self, account_name: &str) -> Result<()> {
+        let accounts = self.load_config()?;
+        let account = accounts
+            .iter()
+            .find(|a| a.name == account_name)
+            .context(format!("Account '{}' not found", account_name))?;
+
+        println!("{}", "Account Information:".bold());
+        println!("{}  {}", "Name:".cyan(), account.name.bold());
+        println!("{}  {}", "Email:".cyan(), account.email);
+        println!(
+            "{}  {}",
+            "SSH Key Path:".cyan(),
+            account.ssh_key_path.display()
+        );
+
+        if let Ok(Some(active)) = self.load_state() {
+            if active == account.name {
+                println!("{}  {}", "Status:".cyan(), "Active".green().bold());
+            } else {
+                println!("{}  {}", "Status:".cyan(), "Inactive".yellow());
+            }
+        }
+
+        println!("\n{}  ", "Public Key:".cyan().bold());
+        println!("{}", account.public_key.green());
 
         Ok(())
     }


### PR DESCRIPTION
This pull request introduces a new `Info` command to retrieve and display detailed information about a specific account in the `gitshift` tool. It includes updates to the CLI, the main command handling logic, and the service layer to support this functionality.

### Command-line Interface Enhancements:
* Added a new `Info` command to the `Commands` enum in `src/cli.rs`, allowing users to retrieve account information by specifying an account name.

### Main Command Handling:
* Updated the `main` function in `src/main.rs` to handle the new `Info` command by invoking the `get_account_info` method from the service layer.

### Service Layer Implementation:
* Introduced the `get_account_info` method in the `GitShift` implementation in `src/service.rs`. This method retrieves account details, including name, email, SSH key path, status (active/inactive), and public key, and formats them for display using the `colored` crate for enhanced output.

### Dependency Updates:
* Added the `colored` crate to `src/service.rs` to enable colorized and styled terminal output for account information.