### PR TITLE
workflow: added github action to autobump before release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,16 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Extract version from Git tag
+        id: extract_version
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Update Cargo.toml version
+        run: |
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+      - name: Publish to crates.io
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   github-release:
     name: Upload Binaries to GitHub Release


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release.yaml` to dynamically extract the version from the Git tag and update the `Cargo.toml` file before publishing to crates.io.

Improvements to the release workflow:

* Added a step to extract the version from the Git tag and store it in the `GITHUB_ENV` environment variable. (`[.github/workflows/release.yamlL50-R59](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL50-R59)`)
* Introduced a step to update the `version` field in `Cargo.toml` dynamically using the extracted version. (`[.github/workflows/release.yamlL50-R59](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL50-R59)`)