### PR TITLE
Feat/remove command: new command to remove existing accounts

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2023 Git-Editor
+Copyright (c) 2023 GitShift
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,8 @@ pub enum Commands {
     Clone { repo_url: String },
     /// Add a new github account
     Add,
+    /// Remove an existing github account
+    Rm,
     /// Get information about a specific account
     Info { account_name: String },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         Commands::Clone { repo_url } => gitshift.clone_repo(&repo_url)?,
         Commands::Info { account_name } => gitshift.get_account_info(&account_name)?,
         Commands::Add => gitshift.add_account()?,
+        Commands::Rm => gitshift.remove_account()?,
     }
 
     Ok(())


### PR DESCRIPTION
This pull request introduces a new feature to remove GitHub accounts from the configuration, updates the licensing information, and includes minor structural changes for improved functionality. Below is a breakdown of the most important changes:

### New Feature: Remove GitHub Account
* Added a new `Rm` command to the `Commands` enum in `src/cli.rs` to allow users to remove GitHub accounts.
* Implemented the `remove_account` method in `src/service.rs` to handle account removal, including listing accounts, selecting one to remove, deleting its SSH key, and updating the configuration.
* Updated the `main` function in `src/main.rs` to handle the `Rm` command by calling the new `remove_account` method.

### Licensing Update
* Updated the copyright holder in `LICENSE.md` from "Git-Editor" to "GitShift."

### Structural Improvements
* Marked the `Account` struct in `src/service.rs` as `Clone` to facilitate cloning during account removal operations.